### PR TITLE
Fix touch drag scrolling

### DIFF
--- a/js/game_esquive.js
+++ b/js/game_esquive.js
@@ -32,11 +32,13 @@ function startEsquiveMode() {
   let lastPos = null;
 
   canvas.ontouchstart = e => {
+    e.preventDefault();
     dragging = true;
     const touch = e.touches[0];
     lastPos = { x: touch.clientX, y: touch.clientY };
   };
   canvas.ontouchmove = e => {
+    e.preventDefault();
     if (!dragging) return;
     const touch = e.touches[0];
     const dx = touch.clientX - lastPos.x;

--- a/js/game_safezone.js
+++ b/js/game_safezone.js
@@ -32,11 +32,13 @@ function startSafeZoneMode() {
   let lastPos = null;
 
   canvas.ontouchstart = e => {
+    e.preventDefault();
     dragging = true;
     const touch = e.touches[0];
     lastPos = { x: touch.clientX, y: touch.clientY };
   };
   canvas.ontouchmove = e => {
+    e.preventDefault();
     if (!dragging) return;
     const touch = e.touches[0];
     const dx = touch.clientX - lastPos.x;

--- a/style.css
+++ b/style.css
@@ -128,6 +128,7 @@ main {
   background: #181824;
   border: 3px solid #222246;
   border-radius: 18px;
+  touch-action: none;
   margin-bottom: 2.2rem;
   box-shadow: 0 4px 24px rgba(50,50,110,0.18);
   transition: border 0.2s;


### PR DESCRIPTION
## Summary
- add `e.preventDefault()` in mobile drag handlers
- disable touch scrolling via CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d80c1e848321987e84d6e74d8d7f