### PR TITLE
Fix script loading order and remove dead reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,17 +33,15 @@
     <p>&copy; 2025 VZone</p>
   </footer>
 
-  <!-- Scripts langues existants UNIQUEMENT -->
-  <script src="js/lang/fr.js"></script>
-  <!-- Ajouter d'autres langues ici quand tu les auras créées -->
-
   <!-- Scripts principaux -->
   <script src="js/core.js"></script>
   <script src="js/game_esquive.js"></script>
   <script src="js/game_safezone.js"></script>
-  <script src="js/vzone.js"></script>
   <script src="js/vzone_i18n.js"></script>
   <script src="js/vzone_lang.js"></script>
+  <!-- Scripts langues existants UNIQUEMENT -->
+  <script src="js/lang/fr.js"></script>
+  <!-- Ajouter d'autres langues ici quand tu les auras créées -->
   <script src="js/orientation.js"></script>
   <!-- NE PAS inclure shop.js, settings.js, loader.js s'ils n'existent pas dans /js/ -->
 


### PR DESCRIPTION
## Summary
- remove inclusion of `js/vzone.js` (HTML doesn't contain its expected DOM
  elements)
- load translation script after `vzone_i18n.js` so `registerTranslations` is defined

## Testing
- `node` + jsdom load of `index.html`

------
https://chatgpt.com/codex/tasks/task_e_6841d80455348321a476dfe2240dd6a6