### PR TITLE
Fix missing DOM script reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@
   <script src="js/core.js"></script>
   <script src="js/game_esquive.js"></script>
   <script src="js/game_safezone.js"></script>
-  <script src="js/vzone.js"></script>
   <script src="js/vzone_i18n.js"></script>
   <script src="js/orientation.js"></script>
   <!-- NE PAS inclure shop.js, settings.js, loader.js s'ils n'existent pas dans /js/ -->


### PR DESCRIPTION
## Summary
- remove reference to unused `js/vzone.js`

## Testing
- `npm test`
- `node - <<'NODE'
const { JSDOM } = require('jsdom');
JSDOM.fromFile('index.html', {
  runScripts: 'dangerously',
  resources: 'usable',
  pretendToBeVisual: true,
  beforeParse(win){ win.matchMedia = () => ({ matches:false, addListener(){}, removeListener(){} }); }
}).then(dom => { dom.window.addEventListener('load', () => { console.log('loaded'); dom.window.close(); }); });
NODE

------
https://chatgpt.com/codex/tasks/task_e_68448b7046148321b2e9dc9c194c9954