### PR TITLE
Fix: hide game canvas on home screen

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -26,11 +26,43 @@ function clearAllEvents() {
   document.ontouchend = null;
 }
 
+// Affiche ou masque le canvas
+function showCanvas() {
+  const canvas = document.getElementById('gameCanvas');
+  if (canvas) canvas.style.display = 'block';
+}
+
+function hideCanvas() {
+  const canvas = document.getElementById('gameCanvas');
+  if (canvas) canvas.style.display = 'none';
+}
+
+// Affiche ou masque le menu principal
+function showMenu() {
+  const menu = document.querySelector('.menu-principal');
+  if (menu) menu.style.display = 'flex';
+}
+
+function hideMenu() {
+  const menu = document.querySelector('.menu-principal');
+  if (menu) menu.style.display = 'none';
+}
+
+function returnToMenu() {
+  hideOverlay();
+  hideCanvas();
+  showMenu();
+  resetGameCanvas();
+  clearAllEvents();
+}
+
 // Lance le bon mode de jeu selon le paramètre (esquive ou safezone)
 function launchMode(mode) {
   resetGameCanvas();
   clearAllEvents();
   hideOverlay();
+  hideMenu();
+  showCanvas();
 
   if (mode === 'esquive' && typeof startEsquiveMode === 'function') {
     startEsquiveMode();
@@ -73,6 +105,14 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 if (typeof module !== "undefined") {
-  module.exports = { resizeCanvas, clearAllEvents };
+  module.exports = {
+    resizeCanvas,
+    clearAllEvents,
+    showCanvas,
+    hideCanvas,
+    showMenu,
+    hideMenu,
+    returnToMenu
+  };
 }
 

--- a/js/game_esquive.js
+++ b/js/game_esquive.js
@@ -143,7 +143,7 @@ function showGameOverEsquive(score) {
       <h2 style="color:#f1c40f">${t('game_over_title')}</h2>
       <p style="font-size:1.3em;color:#fff;margin:0.6em 0 1.3em 0;">${t('score_label')} <b>${score.toFixed(1)}</b></p>
       <button class="main-button" onclick="hideOverlay();launchMode('esquive')">${t('retry')}</button>
-      <button class="sub-btn" style="margin-left:0.5em" onclick="hideOverlay()">${t('menu')}</button>
+      <button class="sub-btn" style="margin-left:0.5em" onclick="returnToMenu()">${t('menu')}</button>
     </div>
   `);
 }

--- a/js/game_safezone.js
+++ b/js/game_safezone.js
@@ -139,7 +139,7 @@ function showVictorySafeZone(score) {
         Tu as cumulé <b>${score.toFixed(1)} s</b> dans la zone !
       </p>
       <button class="main-button" onclick="hideOverlay();launchMode('safe')">${t('retry')}</button>
-      <button class="sub-btn" style="margin-left:0.5em" onclick="hideOverlay()">${t('menu')}</button>
+      <button class="sub-btn" style="margin-left:0.5em" onclick="returnToMenu()">${t('menu')}</button>
     </div>
   `);
 }

--- a/style.css
+++ b/style.css
@@ -132,7 +132,7 @@ main {
   margin-bottom: 2.2rem;
   box-shadow: 0 4px 24px rgba(50,50,110,0.18);
   transition: border 0.2s;
-  display: block;
+  display: none;
 }
 
 #uiOverlay, .ui-overlay {


### PR DESCRIPTION
## Summary
- hide the canvas by default so only menu buttons show on the main page
- add functions in core.js to show/hide the canvas and menu
- toggle canvas/menu visibility when launching or leaving a game
- update game over overlays to use the new `returnToMenu()` function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844ae6f85948321a5e856befc0b0456