### PR TITLE
Add player color selection tests and functionality

### DIFF
--- a/__tests__/shop-colors.test.js
+++ b/__tests__/shop-colors.test.js
@@ -1,0 +1,53 @@
+let applyTheme, selectPlayerColor;
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = '';
+  localStorage.clear();
+  ({ applyTheme, selectPlayerColor } = require('../js/shop'));
+});
+
+describe('shop color selection', () => {
+  test('applyTheme updates CSS variable', () => {
+    applyTheme('neon');
+    expect(document.body.style.getPropertyValue('--main-color')).toBe('#00ffe7');
+  });
+
+  test('selectPlayerColor stores value and updates CSS', () => {
+    selectPlayerColor('#123456');
+    expect(localStorage.getItem('vzone-player-color')).toBe('#123456');
+    expect(document.body.style.getPropertyValue('--player-color')).toBe('#123456');
+  });
+});
+
+describe('game modules read stored color', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<canvas id="gameCanvas"></canvas>';
+    const canvas = document.getElementById('gameCanvas');
+    canvas.getContext = () => ({
+      clearRect: jest.fn(),
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      fillText: jest.fn()
+    });
+    localStorage.setItem('vzone-player-color', '#abcdef');
+    global.requestAnimationFrame = jest.fn();
+    global.cancelAnimationFrame = jest.fn();
+    global.resizeCanvas = jest.fn();
+    global.clearAllEvents = jest.fn();
+  });
+
+  test('esquive mode uses stored color', () => {
+    const { startEsquiveMode } = require('../js/game_esquive');
+    const player = startEsquiveMode(true);
+    expect(player.color).toBe('#abcdef');
+  });
+
+  test('safezone mode uses stored color', () => {
+    const { startSafeZoneMode } = require('../js/game_safezone');
+    const player = startSafeZoneMode(true);
+    expect(player.color).toBe('#abcdef');
+  });
+});

--- a/js/game_esquive.js
+++ b/js/game_esquive.js
@@ -4,15 +4,15 @@ let esquiveRunning = false;
 let player, obstacles = [], esquiveScore = 0, level = 0;
 let esquiveInterval = null, esquiveAnimFrame = null;
 
-function startEsquiveMode() {
+function startEsquiveMode(testing = false) {
   esquiveRunning = true;
   esquiveScore = 0;
-  player = { 
-    x: 110, 
-    y: 110, 
-    radius: 19, 
-    speed: 5, 
-    color: "#f1c40f" 
+  player = {
+    x: 110,
+    y: 110,
+    radius: 19,
+    speed: 5,
+    color: localStorage.getItem('vzone-player-color') || '#f1c40f'
   };
   obstacles = [];
   level = 0;
@@ -157,7 +157,8 @@ function startEsquiveMode() {
     esquiveAnimFrame = requestAnimationFrame(update);
   }
 
-  update();
+  if (!testing) update();
+  return player;
 }
 
 // Affiche un écran game over avec score (overlay)
@@ -170,4 +171,8 @@ function showGameOverEsquive(score) {
       <button class="sub-btn" style="margin-left:0.5em" onclick="returnToMenu()">${t('menu')}</button>
     </div>
   `);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { startEsquiveMode };
 }

--- a/js/game_safezone.js
+++ b/js/game_safezone.js
@@ -5,10 +5,11 @@ let playerSZ, safeZone, timeInside = 0, totalRequired = 30;
 let safezoneAnimFrame = null, szMoveInterval = null;
 let obstaclesSZ = [], levelSZ = 0, obsIntervalSZ = null;
 
-function startSafeZoneMode() {
+function startSafeZoneMode(testing = false) {
   safeZoneRunning = true;
   timeInside = 0;
-  playerSZ = { x: 110, y: 110, radius: 19, speed: 4, color: "#3498db" };
+  playerSZ = { x: 110, y: 110, radius: 19, speed: 4,
+    color: localStorage.getItem('vzone-player-color') || '#f1c40f' };
 
   const canvas = document.getElementById('gameCanvas');
   const ctx = canvas.getContext('2d');
@@ -177,7 +178,8 @@ function startSafeZoneMode() {
     safezoneAnimFrame = requestAnimationFrame(update);
   }
 
-  update();
+  if (!testing) update();
+  return playerSZ;
 }
 
 // Overlay victoire SafeZone
@@ -204,4 +206,8 @@ function showGameOverSafeZone(score) {
       <button class="sub-btn" style="margin-left:0.5em" onclick="returnToMenu()">${t('menu')}</button>
     </div>
   `);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { startSafeZoneMode };
 }

--- a/js/shop.js
+++ b/js/shop.js
@@ -23,6 +23,7 @@ const THEMES = [
 ];
 
 let currentTheme = localStorage.getItem('vzone-theme') || 'classic';
+let currentPlayerColor = localStorage.getItem('vzone-player-color') || '#f1c40f';
 
 function openShop() {
   let html = `<div style="background:#222238;padding:2em 1.2em;border-radius:22px;min-width:260px;max-width:98vw;text-align:center;box-shadow:0 6px 30px #0008">
@@ -71,6 +72,16 @@ function applyTheme(themeId) {
   // Tu peux customiser ici pour changer aussi le fond, le canvas, etc.
 }
 
+function selectPlayerColor(color) {
+  currentPlayerColor = color;
+  localStorage.setItem('vzone-player-color', color);
+  applyPlayerColor(color);
+}
+
+function applyPlayerColor(color) {
+  document.body.style.setProperty('--player-color', color);
+}
+
 // Utilitaire pour traduction dans la boutique
 function getTrad(key) {
   return translations[currentLang] && translations[currentLang][key]
@@ -83,4 +94,9 @@ window.addEventListener('DOMContentLoaded', () => {
   const btnShop = document.getElementById('shopButton');
   if (btnShop) btnShop.onclick = openShop;
   applyTheme(currentTheme);
+  applyPlayerColor(currentPlayerColor);
 });
+
+if (typeof module !== 'undefined') {
+  module.exports = { applyTheme, selectPlayerColor, applyPlayerColor };
+}

--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
 /* === VZONE STYLE GLOBAL STUDIO === */
 :root {
   --main-color: #4e63ea;
+  --player-color: #f1c40f;
   --accent-color: #f1c40f;
   --bg-color: #1e1e2f;
   --ui-bg: #222238;


### PR DESCRIPTION
## Summary
- support selecting a player color and store it in `localStorage`
- apply player color using CSS variable `--player-color`
- games read saved color when starting
- export functions for tests
- add new Jest tests for shop color selection and game usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a1f961208321aab3b1d2cd1e030a