### PR TITLE
Add customizable colors

### DIFF
--- a/js/game_esquive.js
+++ b/js/game_esquive.js
@@ -7,12 +7,18 @@ let esquiveInterval = null, esquiveAnimFrame = null;
 function startEsquiveMode() {
   esquiveRunning = true;
   esquiveScore = 0;
-  player = { 
-    x: 110, 
-    y: 110, 
-    radius: 19, 
-    speed: 5, 
-    color: "#f1c40f" 
+  const pId = localStorage.getItem('vzone-player-color') || (PLAYER_COLORS && PLAYER_COLORS[0].id);
+  const eId = localStorage.getItem('vzone-enemy-color') || (ENEMY_COLORS && ENEMY_COLORS[0].id);
+  const pOpt = (typeof PLAYER_COLORS !== 'undefined') ? PLAYER_COLORS.find(c => c.id === pId) : null;
+  const eOpt = (typeof ENEMY_COLORS !== 'undefined') ? ENEMY_COLORS.find(c => c.id === eId) : null;
+  const playerColor = pOpt ? pOpt.color : '#f1c40f';
+  const enemyColor = eOpt ? eOpt.color : '#e74c3c';
+  player = {
+    x: 110,
+    y: 110,
+    radius: 19,
+    speed: 5,
+    color: playerColor
   };
   obstacles = [];
   level = 0;
@@ -41,7 +47,7 @@ function startEsquiveMode() {
       radius: r,
       dx: speed * Math.cos(angle),
       dy: speed * Math.sin(angle),
-      color: "#e74c3c"
+      color: enemyColor
     });
   }
 

--- a/js/game_safezone.js
+++ b/js/game_safezone.js
@@ -5,10 +5,26 @@ let playerSZ, safeZone, timeInside = 0, totalRequired = 30;
 let safezoneAnimFrame = null, szMoveInterval = null;
 let obstaclesSZ = [], levelSZ = 0, obsIntervalSZ = null;
 
+function hexToRGBA(hex, alpha) {
+  const r = parseInt(hex.slice(1,3),16);
+  const g = parseInt(hex.slice(3,5),16);
+  const b = parseInt(hex.slice(5,7),16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 function startSafeZoneMode() {
   safeZoneRunning = true;
   timeInside = 0;
-  playerSZ = { x: 110, y: 110, radius: 19, speed: 4, color: "#3498db" };
+  const pId = localStorage.getItem('vzone-player-color') || (PLAYER_COLORS && PLAYER_COLORS[0].id);
+  const eId = localStorage.getItem('vzone-enemy-color') || (ENEMY_COLORS && ENEMY_COLORS[0].id);
+  const zId = localStorage.getItem('vzone-zone-color') || (ZONE_COLORS && ZONE_COLORS[0].id);
+  const pOpt = (typeof PLAYER_COLORS !== 'undefined') ? PLAYER_COLORS.find(c => c.id === pId) : null;
+  const eOpt = (typeof ENEMY_COLORS !== 'undefined') ? ENEMY_COLORS.find(c => c.id === eId) : null;
+  const zOpt = (typeof ZONE_COLORS !== 'undefined') ? ZONE_COLORS.find(c => c.id === zId) : null;
+  const playerColor = pOpt ? pOpt.color : '#3498db';
+  const enemyColor = eOpt ? eOpt.color : '#e74c3c';
+  const zoneBase = zOpt ? zOpt.color : '#41ff7d';
+  playerSZ = { x: 110, y: 110, radius: 19, speed: 4, color: playerColor };
 
   const canvas = document.getElementById('gameCanvas');
   const ctx = canvas.getContext('2d');
@@ -35,7 +51,7 @@ function startSafeZoneMode() {
       radius: r,
       dx: speed * Math.cos(angle),
       dy: speed * Math.sin(angle),
-    color: "#e74c3c"
+    color: enemyColor
     });
   }
 
@@ -111,7 +127,7 @@ function startSafeZoneMode() {
     // Safe zone (rond vert semi-transparent)
     ctx.beginPath();
     ctx.arc(safeZone.x, safeZone.y, safeZone.radius, 0, 2 * Math.PI);
-    ctx.fillStyle = "rgba(65, 255, 125, 0.23)";
+    ctx.fillStyle = hexToRGBA(zoneBase, 0.23);
     ctx.shadowColor = "#b0faac";
     ctx.shadowBlur = 10;
     ctx.fill();

--- a/js/lang/fr.js
+++ b/js/lang/fr.js
@@ -5,7 +5,10 @@ registerTranslations('fr', {
   "bouton_jouer_safezone": "Jouer : SafeZone",
   "bouton_boutique": "Boutique",
   "bouton_parametres": "Paramètres",
-  "titre_jeu": "VZone"
+  "titre_jeu": "VZone",
+  "label_player_color": "Couleur du joueur",
+  "label_enemy_color": "Couleur des ennemis",
+  "label_zone_color": "Couleur de la zone"
   // Ajoute ici d’autres textes au besoin :
   // "profil": "Profil",
   // "meilleur_score": "Meilleur score",

--- a/js/shop.js
+++ b/js/shop.js
@@ -22,37 +22,73 @@ const THEMES = [
   // ...ajoute autant de thèmes que tu veux ici
 ];
 
+const PLAYER_COLORS = [
+  { id: 'yellow', name: { fr: 'Jaune', en: 'Yellow' }, color: '#f1c40f', preview: '#f1c40f' },
+  { id: 'blue',   name: { fr: 'Bleu',  en: 'Blue' },   color: '#3498db', preview: '#3498db' },
+  { id: 'green',  name: { fr: 'Vert',  en: 'Green' },  color: '#2ecc71', preview: '#2ecc71' },
+  { id: 'purple', name: { fr: 'Violet',en: 'Purple' }, color: '#9b59b6', preview: '#9b59b6' }
+];
+
+const ENEMY_COLORS = [
+  { id: 'red',    name: { fr: 'Rouge',  en: 'Red' },    color: '#e74c3c', preview: '#e74c3c' },
+  { id: 'orange', name: { fr: 'Orange', en: 'Orange' }, color: '#e67e22', preview: '#e67e22' },
+  { id: 'magenta',name: { fr: 'Magenta',en: 'Magenta'}, color: '#e91e63', preview: '#e91e63' },
+  { id: 'teal',   name: { fr: 'Sarcelle',en: 'Teal' },  color: '#1abc9c', preview: '#1abc9c' }
+];
+
+const ZONE_COLORS = [
+  { id: 'green',  name: { fr: 'Vert',  en: 'Green' },  color: '#41ff7d', preview: '#41ff7d' },
+  { id: 'cyan',   name: { fr: 'Cyan',  en: 'Cyan' },   color: '#00ffe7', preview: '#00ffe7' },
+  { id: 'pink',   name: { fr: 'Rose',  en: 'Pink' },   color: '#ff69b4', preview: '#ff69b4' },
+  { id: 'orange', name: { fr: 'Orange',en: 'Orange' }, color: '#ff8c42', preview: '#ff8c42' }
+];
+
 let currentTheme = localStorage.getItem('vzone-theme') || 'classic';
+let currentPlayerColor = localStorage.getItem('vzone-player-color') || PLAYER_COLORS[0].id;
+let currentEnemyColor = localStorage.getItem('vzone-enemy-color') || ENEMY_COLORS[0].id;
+let currentZoneColor = localStorage.getItem('vzone-zone-color') || ZONE_COLORS[0].id;
 
-function openShop() {
-  let html = `<div style="background:#222238;padding:2em 1.2em;border-radius:22px;min-width:260px;max-width:98vw;text-align:center;box-shadow:0 6px 30px #0008">
-    <h2 style="color:#f1c40f;margin-bottom:1em;">${getTrad("bouton_boutique")}</h2>
-    <div style="display:flex;gap:1.5em;justify-content:center;margin-bottom:1.6em;flex-wrap:wrap;">`;
-
-  THEMES.forEach(th => {
-    const isActive = (th.id === currentTheme);
-    html += `
-      <div onclick="selectTheme('${th.id}')" style="
+function optionHTML(list, currentId, cbName) {
+  let out = '';
+  list.forEach(opt => {
+    const active = opt.id === currentId;
+    out += `
+      <div onclick="${cbName}('${opt.id}')" style="
         width:70px;height:70px;
         margin-bottom:0.6em;
         border-radius:20px;
         box-shadow:0 2px 12px #0003;
-        border:4px solid ${isActive ? '#f1c40f' : '#232342'};
-        background:${th.preview};
+        border:4px solid ${active ? '#f1c40f' : '#232342'};
+        background:${opt.preview};
         cursor:pointer;
         display:flex;align-items:end;justify-content:center;
-        position:relative;
-        ">
-        ${isActive ? `<span style="position:absolute;top:8px;right:9px;color:#f1c40f;font-size:1.3em;">★</span>` : ""}
-        <span style="font-size:0.97em;color:#fff;padding-bottom:0.35em;font-weight:600;text-shadow:0 1px 7px #0005">
-          ${th.name[currentLang] || th.name["en"]}
+        position:relative;">
+        ${active ? `<span style="position:absolute;top:8px;right:9px;color:#f1c40f;font-size:1.3em;">★</span>` : ''}
+        <span style="font-size:0.85em;color:#fff;padding-bottom:0.35em;font-weight:600;text-shadow:0 1px 7px #0005">
+          ${opt.name[currentLang] || opt.name['en']}
         </span>
-      </div>
-    `;
+      </div>`;
   });
+  return out;
+}
 
-  html += `</div>
-    <button class="sub-btn" onclick="hideOverlay()">${getTrad("bouton_parametres") || "Retour"}</button>
+function openShop() {
+  let html = `<div style="background:#222238;padding:2em 1.2em;border-radius:22px;min-width:260px;max-width:98vw;text-align:center;box-shadow:0 6px 30px #0008">
+    <h2 style="color:#f1c40f;margin-bottom:1em;">${getTrad('bouton_boutique')}</h2>`;
+
+  html += `<h3 style="margin:0.4em 0;color:#fff;">${getTrad('theme')}</h3>`;
+  html += `<div class="shop-grid">${optionHTML(THEMES, currentTheme, 'selectTheme')}</div>`;
+
+  html += `<h3 style="margin:0.7em 0 0.3em 0;color:#fff;">${getTrad('label_player_color')}</h3>`;
+  html += `<div class="shop-grid">${optionHTML(PLAYER_COLORS, currentPlayerColor, 'selectPlayerColor')}</div>`;
+
+  html += `<h3 style="margin:0.7em 0 0.3em 0;color:#fff;">${getTrad('label_enemy_color')}</h3>`;
+  html += `<div class="shop-grid">${optionHTML(ENEMY_COLORS, currentEnemyColor, 'selectEnemyColor')}</div>`;
+
+  html += `<h3 style="margin:0.7em 0 0.3em 0;color:#fff;">${getTrad('label_zone_color')}</h3>`;
+  html += `<div class="shop-grid">${optionHTML(ZONE_COLORS, currentZoneColor, 'selectZoneColor')}</div>`;
+
+  html += `<button class="sub-btn" onclick="hideOverlay()">${getTrad('bouton_parametres') || 'Retour'}</button>
   </div>`;
   showOverlay(html);
 }
@@ -61,6 +97,24 @@ function selectTheme(themeId) {
   currentTheme = themeId;
   localStorage.setItem('vzone-theme', themeId);
   applyTheme(themeId);
+  openShop();
+}
+
+function selectPlayerColor(colorId) {
+  currentPlayerColor = colorId;
+  localStorage.setItem('vzone-player-color', colorId);
+  openShop();
+}
+
+function selectEnemyColor(colorId) {
+  currentEnemyColor = colorId;
+  localStorage.setItem('vzone-enemy-color', colorId);
+  openShop();
+}
+
+function selectZoneColor(colorId) {
+  currentZoneColor = colorId;
+  localStorage.setItem('vzone-zone-color', colorId);
   openShop();
 }
 

--- a/js/vzone_i18n.js
+++ b/js/vzone_i18n.js
@@ -33,6 +33,9 @@ const translations = {
     game_over_title: 'Game Over !',
     victory_title: 'Bravo !',
     score_label: 'Score :',
+    label_player_color: 'Couleur du joueur',
+    label_enemy_color: 'Couleur des ennemis',
+    label_zone_color: 'Couleur de la zone',
     rotate_message: 'Veuillez tourner votre appareil'
   },
   en: {
@@ -64,6 +67,9 @@ const translations = {
     game_over_title: 'Game Over!',
     victory_title: 'Well done!',
     score_label: 'Score:',
+    label_player_color: 'Player color',
+    label_enemy_color: 'Enemy color',
+    label_zone_color: 'Zone color',
     rotate_message: 'Please rotate your device'
   },
   de: {

--- a/style.css
+++ b/style.css
@@ -78,6 +78,14 @@ main {
   z-index: 2;
 }
 
+.shop-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+  gap: 1em;
+  justify-items: center;
+  margin-bottom: 1.2em;
+}
+
 .main-button,
 .main-btn, .sub-btn, .danger-btn, .icon-btn {
   display: inline-block;


### PR DESCRIPTION
## Summary
- extend shop with player, enemy and zone color options
- load selected colors for game objects
- add translation keys for new labels
- style grid layout for color selection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a3512f1c8321a4d122989ecbd97a