### PR TITLE
Make canvas fullscreen and shrink game objects

### DIFF
--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -1,13 +1,13 @@
 const { resizeCanvas, clearAllEvents } = require('../js/core');
 
 describe('resizeCanvas', () => {
-  test('sets canvas dimensions within limits', () => {
+  test('sets canvas dimensions to window size', () => {
     const canvas = document.createElement('canvas');
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1000 });
     Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
     resizeCanvas(canvas);
-    expect(canvas.width).toBeLessThanOrEqual(520);
-    expect(canvas.height).toBeLessThanOrEqual(390);
+    expect(canvas.width).toBe(1000);
+    expect(canvas.height).toBe(800);
   });
 });
 

--- a/js/core.js
+++ b/js/core.js
@@ -1,12 +1,9 @@
 // === VZone - core.js ===
 
-// Redimensionne le canvas selon la fenêtre et le ratio voulu (responsive)
+// Redimensionne le canvas pour occuper tout l'écran
 function resizeCanvas(canvas) {
-  const ratio = window.innerWidth / window.innerHeight;
-  const width = Math.min(window.innerWidth * 0.96, 520);
-  const height = Math.min(window.innerHeight * 0.52, 390);
-  canvas.width = width;
-  canvas.height = height;
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
 }
 
 // Nettoie le canvas
@@ -47,6 +44,20 @@ function hideBackButton() {
   if (b) b.style.display = 'none';
 }
 
+function hideHud() {
+  const header = document.querySelector('header');
+  const footer = document.querySelector('footer');
+  if (header) header.style.display = 'none';
+  if (footer) footer.style.display = 'none';
+}
+
+function showHud() {
+  const header = document.querySelector('header');
+  const footer = document.querySelector('footer');
+  if (header) header.style.display = '';
+  if (footer) footer.style.display = '';
+}
+
 // Affiche ou masque le menu principal
 function showMenu() {
   const menu = document.querySelector('.menu-principal');
@@ -65,6 +76,7 @@ function returnToMenu() {
   resetGameCanvas();
   clearAllEvents();
   hideBackButton();
+  showHud();
 }
 
 // Lance le bon mode de jeu selon le paramètre (esquive ou safezone)
@@ -75,6 +87,7 @@ function launchMode(mode) {
   hideMenu();
   showCanvas();
   showBackButton();
+  hideHud();
 
   if (mode === 'esquive' && typeof startEsquiveMode === 'function') {
     startEsquiveMode();
@@ -126,7 +139,9 @@ if (typeof module !== "undefined") {
     hideMenu,
     returnToMenu,
     showBackButton,
-    hideBackButton
+    hideBackButton,
+    hideHud,
+    showHud
   };
 }
 

--- a/js/game_esquive.js
+++ b/js/game_esquive.js
@@ -10,7 +10,7 @@ function startEsquiveMode(testing = false) {
   player = {
     x: 110,
     y: 110,
-    radius: 19,
+    radius: 12,
     speed: 5,
     color: localStorage.getItem('vzone-player-color') || '#f1c40f'
   };
@@ -19,8 +19,8 @@ function startEsquiveMode(testing = false) {
 
   function addObstacle() {
     level++;
-    const base = 18;
-    const r = base + level * 2;
+    const base = 12;
+    const r = base + level * 1.5;
     let speed = 2;
     if (level > 3) speed += (level - 3) * 0.4;
     const angle = Math.random() * Math.PI * 2;

--- a/js/game_safezone.js
+++ b/js/game_safezone.js
@@ -8,7 +8,7 @@ let obstaclesSZ = [], levelSZ = 0, obsIntervalSZ = null;
 function startSafeZoneMode(testing = false) {
   safeZoneRunning = true;
   timeInside = 0;
-  playerSZ = { x: 110, y: 110, radius: 19, speed: 4,
+  playerSZ = { x: 110, y: 110, radius: 12, speed: 4,
     color: localStorage.getItem('vzone-player-color') || '#f1c40f' };
 
   const canvas = document.getElementById('gameCanvas');
@@ -19,15 +19,15 @@ function startSafeZoneMode(testing = false) {
   safeZone = {
     x: Math.random() * (canvas.width - 140) + 70,
     y: Math.random() * (canvas.height - 140) + 70,
-    radius: 54
+    radius: 40
   };
   obstaclesSZ = [];
   levelSZ = 0;
 
   function addObstacleSZ() {
     levelSZ++;
-    const base = 18;
-    const r = base + levelSZ * 2;
+    const base = 12;
+    const r = base + levelSZ * 1.5;
     const speed = 2 + levelSZ * 0.4;
     const angle = Math.random() * Math.PI * 2;
     obstaclesSZ.push({

--- a/style.css
+++ b/style.css
@@ -130,15 +130,15 @@ main {
 }
 
 #gameCanvas {
-  width: 92vw;
-  max-width: 500px;
-  height: 54vw;
-  max-height: 410px;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
   background: #181824;
   border: 3px solid #222246;
   border-radius: 18px;
   touch-action: none;
-  margin-bottom: 2.2rem;
+  margin: 0;
   box-shadow: 0 4px 24px rgba(50,50,110,0.18);
   transition: border 0.2s;
   display: none;
@@ -210,11 +210,11 @@ footer {
     font-size: 0.98rem;
   }
   #gameCanvas {
-    width: 97vw;
-    max-width: 98vw;
-    height: 54vw;
-    max-height: 260px;
-    min-height: 190px;
+    width: 100vw;
+    height: 100vh;
+    max-width: none;
+    max-height: none;
+    min-height: 0;
   }
   main {
     min-height: 280px;
@@ -232,11 +232,12 @@ footer {
     margin-bottom: 1.3rem;
   }
   #gameCanvas {
-    width: 99vw;
-    max-width: 99vw;
-    min-height: 120px;
-    max-height: 210px;
-    margin-bottom: 1.3rem;
+    width: 100vw;
+    height: 100vh;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    min-height: 0;
   }
   h1, .logo-title {
     font-size: 1.15rem;
@@ -253,10 +254,10 @@ footer {
     display: none;
   }
   #gameCanvas {
-    width: 80vh;
-    max-width: 80vh;
-    height: 48vh;
-    max-height: 48vh;
+    width: 100vw;
+    height: 100vh;
+    max-width: none;
+    max-height: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- resize canvas to always use the full viewport
- hide header and footer during gameplay
- make bubble sprites smaller
- adjust responsive CSS for full screen canvas
- update tests for new dimensions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d8ad19a0832199f1acc1c3915035