### PR TITLE
Remove CommonJS exports and adjust tests

### DIFF
--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -1,4 +1,19 @@
-const { resizeCanvas, clearAllEvents } = require('../js/core');
+const fs = require('fs');
+const path = require('path');
+
+function load(file) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'js', file), 'utf8');
+  const script = document.createElement('script');
+  script.textContent = code;
+  document.head.appendChild(script);
+}
+
+let resizeCanvas, clearAllEvents;
+
+beforeAll(() => {
+  load('core.js');
+  ({ resizeCanvas, clearAllEvents } = window);
+});
 
 describe('resizeCanvas', () => {
   test('sets canvas dimensions to window size', () => {

--- a/__tests__/i18n.test.js
+++ b/__tests__/i18n.test.js
@@ -1,4 +1,19 @@
-const { setLang } = require('../js/vzone_i18n');
+const fs = require('fs');
+const path = require('path');
+
+function load(file) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'js', file), 'utf8');
+  const script = document.createElement('script');
+  script.textContent = code;
+  document.head.appendChild(script);
+}
+
+let setLang;
+
+beforeAll(() => {
+  load('vzone_i18n.js');
+  ({ setLang } = window);
+});
 
 describe('rotate overlay translation', () => {
   beforeEach(() => {

--- a/__tests__/shop-colors.test.js
+++ b/__tests__/shop-colors.test.js
@@ -1,10 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const load = file => {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'js', file), 'utf8');
+  const script = document.createElement('script');
+  script.textContent = code;
+  document.head.appendChild(script);
+};
+
 let applyTheme, selectPlayerColor;
 
+beforeAll(() => {
+  load('shop.js');
+  applyTheme = window.applyTheme;
+  selectPlayerColor = window.selectPlayerColor;
+});
+
 beforeEach(() => {
-  jest.resetModules();
   document.body.innerHTML = '';
   localStorage.clear();
-  ({ applyTheme, selectPlayerColor } = require('../js/shop'));
 });
 
 describe('shop color selection', () => {
@@ -21,8 +35,12 @@ describe('shop color selection', () => {
 });
 
 describe('game modules read stored color', () => {
+  beforeAll(() => {
+    load('game_esquive.js');
+    load('game_safezone.js');
+  });
+
   beforeEach(() => {
-    jest.resetModules();
     document.body.innerHTML = '<canvas id="gameCanvas"></canvas>';
     const canvas = document.getElementById('gameCanvas');
     canvas.getContext = () => ({
@@ -40,14 +58,12 @@ describe('game modules read stored color', () => {
   });
 
   test('esquive mode uses stored color', () => {
-    const { startEsquiveMode } = require('../js/game_esquive');
-    const player = startEsquiveMode(true);
+    const player = window.startEsquiveMode(true);
     expect(player.color).toBe('#abcdef');
   });
 
   test('safezone mode uses stored color', () => {
-    const { startSafeZoneMode } = require('../js/game_safezone');
-    const player = startSafeZoneMode(true);
+    const player = window.startSafeZoneMode(true);
     expect(player.color).toBe('#abcdef');
   });
 });

--- a/js/core.js
+++ b/js/core.js
@@ -129,19 +129,4 @@ window.addEventListener('DOMContentLoaded', () => {
   // Si d’autres boutons/menu à brancher, on peut continuer ici...
 });
 
-if (typeof module !== "undefined") {
-  module.exports = {
-    resizeCanvas,
-    clearAllEvents,
-    showCanvas,
-    hideCanvas,
-    showMenu,
-    hideMenu,
-    returnToMenu,
-    showBackButton,
-    hideBackButton,
-    hideHud,
-    showHud
-  };
-}
 

--- a/js/game_esquive.js
+++ b/js/game_esquive.js
@@ -173,6 +173,3 @@ function showGameOverEsquive(score) {
   `);
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = { startEsquiveMode };
-}

--- a/js/game_safezone.js
+++ b/js/game_safezone.js
@@ -208,6 +208,3 @@ function showGameOverSafeZone(score) {
   `);
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = { startSafeZoneMode };
-}

--- a/js/shop.js
+++ b/js/shop.js
@@ -97,6 +97,3 @@ window.addEventListener('DOMContentLoaded', () => {
   applyPlayerColor(currentPlayerColor);
 });
 
-if (typeof module !== 'undefined') {
-  module.exports = { applyTheme, selectPlayerColor, applyPlayerColor };
-}

--- a/js/vzone_i18n.js
+++ b/js/vzone_i18n.js
@@ -259,12 +259,3 @@ window.addEventListener('DOMContentLoaded', () => {
   setLang(currentLang);
 });
 
-if (typeof module !== 'undefined') {
-  module.exports = {
-    setLang,
-    t,
-    registerTranslations,
-    applyTranslations,
-    translations
-  };
-}


### PR DESCRIPTION
## Summary
- drop Node `module.exports` blocks from browser scripts
- load game scripts in Jest using DOM `<script>` injection
- update tests to reference globals via `window`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853f6818ad483218ddb099d34a70401